### PR TITLE
WL-3663 : If Site doesn't exist, pass the siteId to portal for feedback tool

### DIFF
--- a/hierarchy-portal/handler/src/java/org/sakaiproject/portal/charon/handlers/HierarchyHandler.java
+++ b/hierarchy-portal/handler/src/java/org/sakaiproject/portal/charon/handlers/HierarchyHandler.java
@@ -146,6 +146,7 @@ public class HierarchyHandler extends SiteHandler {
 					}
 					catch (IdUnusedException iuue)
 					{
+						req.setAttribute("siteId", parts[start]);
 						portal.doError(req, res, session, Portal.ERROR_SITE);
 						return END;
 					}


### PR DESCRIPTION
For the case where the site does not exist (e.g., mistyped url, bookmarked deleted site), we want to include the 'siteId' in the Contact Us tool's email which means that we need to pass it through from the Hierarchy Handler to the tool.   