### PR TITLE
WL-3819: For hierarchical sites, pass through site path to Contact Us tool

### DIFF
--- a/hierarchy-portal/handler/src/java/org/sakaiproject/portal/charon/handlers/HierarchyHandler.java
+++ b/hierarchy-portal/handler/src/java/org/sakaiproject/portal/charon/handlers/HierarchyHandler.java
@@ -168,6 +168,7 @@ public class HierarchyHandler extends SiteHandler {
 			if (node == null) {
 				if (site == null)
 				{
+					req.setAttribute("siteId", buildPath(parts, start, parts.length));
 					portal.doError(req, res, session, Portal.ERROR_SITE);
 				} else {
 					super.doSite(req, res, session, site.getId(), pageId, null, null, parts, req.getContextPath()+req.getServletPath());


### PR DESCRIPTION
For mis-typed sites with "/hierarchy/" in the url, we weren't passing through the site path,
e.g., if the site was:

https://staging-werp.bsp.ox.ac.uk/portal/hierarchy/central/oucs/test/adam

and they mis-typed it as:

https://staging-werp.bsp.ox.ac.uk/portal/hierarchy/central/oucs/test/ada

then we weren't passing through:

/central/oucs/test/ada

to the Contact Us tool so that it could include it in its email.