### PR TITLE
WL-281 Make sure chat knows the current site ID.

### DIFF
--- a/hierarchy-portal/handler/src/java/org/sakaiproject/portal/charon/handlers/HierarchyHandler.java
+++ b/hierarchy-portal/handler/src/java/org/sakaiproject/portal/charon/handlers/HierarchyHandler.java
@@ -332,6 +332,9 @@ public class HierarchyHandler extends SiteHandler {
 
 		String prefix = getUrlFragment();
 		String siteUrl = node.getPath();
+
+		rcontext.put("siteId", site.getId());
+
 		if (siteUrl.endsWith("/"))
 		{
 			siteUrl = siteUrl.substring(0, siteUrl.length()-1);


### PR DESCRIPTION
Portal Chat needs to know what the current site ID is so that it can get the presence list and allow users to chat to other users in the current site. As we have our own handler instead of SiteHandler we didn’t have the code to set the siteId in the render context and so chat didn’t know what the current site was.

This change also fixes an issue with the Google analytics not knowing the the site ID either so we should have better tracking of what sites people are accessing.