### PR TITLE
WL-4109 Use hyphens rather than underscores in names

### DIFF
--- a/hierarchy-tool/tool/src/webapp/WEB-INF/velocity/newsite.vm
+++ b/hierarchy-tool/tool/src/webapp/WEB-INF/velocity/newsite.vm
@@ -5,13 +5,13 @@
 		$('#title').keyup( function(e) {
 			var title = e.target.value;
 			title = title.toLowerCase();
-			title = title.replace(/[^a-z,0-9,_ ]/g,"");
-			title = title.replace(/ /g,"_");
-			title = title.replace(/_+/g, "_");
+			title = title.replace(/[^a-z,0-9,\- ]/g,"");
+			title = title.replace(/ /g,"-");
+			title = title.replace(/\-+/g, "-");
 			if (title.length > 12) {
 				title = title.substring(0,12)
 			}
-			if (title.match(/_$/)) {
+			if (title.match(/\-$/)) {
 				title = title.substring(0,title.length-1);
 			}
 			$('#name').val(title);


### PR DESCRIPTION
When choosing a new name for a site URLs are much more friendly in the address bar then underscores.