### PR TITLE
WL-3228 Fixed the errors for ManageControllerTest.

### DIFF
--- a/hierarchy-tool/tool/src/test/org/sakaiproject/hierarchy/tool/vm/DeleteControllerTest.java
+++ b/hierarchy-tool/tool/src/test/org/sakaiproject/hierarchy/tool/vm/DeleteControllerTest.java
@@ -26,16 +26,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.web.servlet.DispatcherServlet;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@TestExecutionListeners(AutowiringTestExecutionListener.class)
+@TestExecutionListeners({DirtiesContextTestExecutionListener.class, AutowiringTestExecutionListener.class})
 @ContextConfiguration(locations = { "classpath:test-resources.xml", "classpath:applicationContext.xml" }, loader = MockWebApplicationContextLoader.class)
 @MockWebApplication(name = "sakai.hierarchy-delete-site", webapp = "src/webapp")
 @Configurable(autowire = Autowire.BY_TYPE)
+@DirtiesContext
 public class DeleteControllerTest {
 
 	@Autowired

--- a/hierarchy-tool/tool/src/test/org/sakaiproject/hierarchy/tool/vm/ManageControllerTest.java
+++ b/hierarchy-tool/tool/src/test/org/sakaiproject/hierarchy/tool/vm/ManageControllerTest.java
@@ -37,10 +37,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.ExpectedException;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.servlet.DispatcherServlet;
 
@@ -49,10 +51,11 @@ import org.springframework.web.servlet.DispatcherServlet;
  * a container.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@TestExecutionListeners(AutowiringTestExecutionListener.class)
+@TestExecutionListeners({DirtiesContextTestExecutionListener.class, AutowiringTestExecutionListener.class})
 @ContextConfiguration(locations = { "classpath:test-resources.xml", "classpath:applicationContext.xml" }, loader = MockWebApplicationContextLoader.class)
 @MockWebApplication(name = "sakai.hierarchy-manager", webapp = "src/webapp")
 @Configurable(autowire = Autowire.BY_TYPE)
+@DirtiesContext
 public class ManageControllerTest {
 
 	@Autowired


### PR DESCRIPTION
Added @DirtiesContext to both the classes to create new Application Context
each time Test is run.

Note:simply using @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST
_METHOD) is not enough to cause the entire Spring context to be reloaded
for each test. Need to also add the DirtiesContextTestExecutionListener
in @TestExecutionListeners.