### PR TITLE
WL-4230 Maintainer can move site now.

### DIFF
--- a/hierarchy-impl/impl/src/java/org/sakaiproject/hierarchy/impl/PortalHierarchyServiceImpl.java
+++ b/hierarchy-impl/impl/src/java/org/sakaiproject/hierarchy/impl/PortalHierarchyServiceImpl.java
@@ -651,7 +651,31 @@ public class PortalHierarchyServiceImpl implements PortalHierarchyService {
 	}
 
 	public boolean canMoveNode(String id) {
-		return securityService.isSuperUser();
+		//first checking if current user is superuser?
+		boolean canMoveNode = securityService.isSuperUser();
+		if(canMoveNode){
+			return canMoveNode;
+		}
+		//As user is not admin, check if he is maintainer for the current node
+		PortalNode parentNode = getNodeById(id);
+		if(parentNode instanceof PortalNodeSite){
+			canMoveNode = siteService.allowUpdateSite(((PortalNodeSite)parentNode).getSite().getId());
+			//if user is not maintainer for the selected site to move, come out of the function
+			if(!canMoveNode){
+				return canMoveNode;
+			}
+		}
+		//user is maintainer for the current site
+		List<PortalNode> nodeChildren = getNodeChildren(id);
+		//Check if node has any children subsites?
+		for(PortalNode childNode : nodeChildren){
+			if(childNode instanceof PortalNodeSite){
+				//if there is a subsite for this node maintaner cannot move the node,break and return
+				canMoveNode = false;
+				break;
+			}
+		}
+		return canMoveNode;
 	}
 
 	public boolean canNewNode(String parentId) {

--- a/hierarchy-tool/tool/src/java/org/sakaiproject/hierarchy/tool/vm/MoveSiteController.java
+++ b/hierarchy-tool/tool/src/java/org/sakaiproject/hierarchy/tool/vm/MoveSiteController.java
@@ -86,7 +86,7 @@ public class MoveSiteController {
 	public ModelAndView cancel(HttpServletRequest request, Model model) {
 		Session session = sessionManager.getCurrentSession();
 		session.removeAttribute(CUT_ID);
-		return handleAllRequests(request, model);
+		return displayHome(model);
 	}
 
 	@RequestMapping(value = "/cancel/move", method = RequestMethod.POST)


### PR DESCRIPTION
Modified moveNode method in PortalHierarchyServiceImpl class to accomodate
the functionality where maintainer of a site can move it in the hierarchy.
if a maintainer has access rights to all children nodes of the moving node
only then the site can be moved.
Right now not checking for children's children nodes for access rights,
this work will be done in future.