### PR TITLE
WL-4286 Use standard SHA1 hashing for nodes.

### DIFF
--- a/hierarchy-api/api/src/java/org/sakaiproject/hierarchy/impl/portal/dao/PortalPersistentNodeDao.java
+++ b/hierarchy-api/api/src/java/org/sakaiproject/hierarchy/impl/portal/dao/PortalPersistentNodeDao.java
@@ -11,8 +11,22 @@ public interface PortalPersistentNodeDao {
 	
 	public abstract void save(PortalPersistentNode node);
 
+	/**
+	 * This is a transitional method that allows path lookups by both the old and new hashes.
+	 * @param oldHash The old hash.
+	 * @param newHash the new hash.
+	 * @return The matched portal node.
+	 * @see #findByPathHash(String)
+	 */
+	PortalPersistentNode findByPathHash(String oldHash, String newHash);
+
 	public abstract List<PortalPersistentNode> findBySiteId(String siteId);
 
+	/**
+	 * This finds a node by a hash.
+	 * @param pathHash The hash.
+	 * @return The matched portal node.
+     */
 	public abstract PortalPersistentNode findByPathHash(String pathHash);
 
 	public abstract PortalPersistentNode findById(String id);

--- a/hierarchy-impl/impl/src/java/org/sakaiproject/hierarchy/impl/portal/dao/PortalPersistentNodeDaoHibernate.java
+++ b/hierarchy-impl/impl/src/java/org/sakaiproject/hierarchy/impl/portal/dao/PortalPersistentNodeDaoHibernate.java
@@ -64,6 +64,16 @@ public class PortalPersistentNodeDaoHibernate extends HibernateDaoSupport implem
 						pathHash));
 	}
 
+	@Override
+	public PortalPersistentNode findByPathHash(String oldHash, String newHash){
+		return (PortalPersistentNode) justFirst(getHibernateTemplate()
+				.find(
+						"from org.sakaiproject.hierarchy.impl.portal.dao.PortalPersistentNode as node " +
+								"where node.pathHash = ? or node.pathHash = ?",
+						oldHash, newHash));
+	}
+
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<PortalPersistentNode> findBySiteId(String siteId) {

--- a/hierarchy-impl/impl/src/test/org/sakaiproject/hierarchy/impl/PortalHierarchyServiceImplTest.java
+++ b/hierarchy-impl/impl/src/test/org/sakaiproject/hierarchy/impl/PortalHierarchyServiceImplTest.java
@@ -1,6 +1,7 @@
 package org.sakaiproject.hierarchy.impl;
 
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.sakaiproject.exception.PermissionException;
 
@@ -18,6 +19,18 @@ public class PortalHierarchyServiceImplTest {
 	public void testNewNodeArgValidationFull() throws PermissionException {
 		PortalHierarchyServiceImpl service = new PortalHierarchyServiceImpl();
 		service.newNode("parentId", "childName", "siteId", "managementSiteId", "redirectUrl", "title", false, false);
+	}
+
+	@Test
+	public void testHash() {
+		// Test the old hashing.
+		Assert.assertEquals("AA4F6CD1CD5C8E2AADEBEDF0B384C29DEA9A34D4", PortalHierarchyServiceImpl.hash("hello"));
+	}
+
+	@Test
+	public void testSha1() {
+		// Test the new hashing (standard SHA1).
+		Assert.assertEquals("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d", PortalHierarchyServiceImpl.sha1("hello"));
 	}
 
 }


### PR DESCRIPTION
This means we hash in the same way as MySQL and everything else. This
means that we can update paths in the database by using SQL.